### PR TITLE
LIST-217 enable scraping of api metrics endpoint

### DIFF
--- a/ci/ci.env
+++ b/ci/ci.env
@@ -1,2 +1,2 @@
 TAG=latest
-HOST=reverse-proxy
+HOST=traefik

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,7 +22,7 @@ services:
       - postgres
     labels:
       - traefik.docker.network=traefik-public
-      - traefik.http.routers.bechdel-lists-api.rule=Host(`${HOST?}`) && PathPrefix(`/api`)
+      - traefik.http.routers.bechdel-lists-api.rule=(Host(`traefik`) || Host(`${HOST?}`)) && PathPrefix(`/api`)
       - traefik.http.routers.bechdel-lists-api.middlewares=api-stripprefix
       - traefik.http.middlewares.api-stripprefix.stripprefix.prefixes=/api
       - traefik.http.services.bechdel-lists-api.loadbalancer.server.port=5000

--- a/docker-compose.traefik-dev.yml
+++ b/docker-compose.traefik-dev.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
 
-  reverse-proxy:
+  traefik:
     # The official v2 Traefik docker image
     image: traefik:v2.2
     # Enables the web UI and tells Traefik to listen to docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,12 +31,15 @@ services:
         - traefik.enable=true
         - traefik.docker.network=traefik-public
         - traefik.constraint-label=traefik-public
-        - traefik.http.routers.bechdel-lists-api.rule=Host(`${HOST?}`) && PathPrefix(`/api`)
-        - traefik.http.routers.bechdel-lists-api.middlewares=api-stripprefix,https-redirect
+        - traefik.http.routers.bechdel-lists-api-http.rule=Host(`${HOST?}`) && PathPrefix(`/api`)
+        - traefik.http.routers.bechdel-lists-api-http.entrypoints=http
+        - traefik.http.routers.bechdel-lists-api-http.middlewares=https-redirect
+        - traefik.http.routers.bechdel-lists-api-https.rule=Host(`${HOST?}`) && PathPrefix(`/api`)
+        - traefik.http.routers.bechdel-lists-api-https.middlewares=api-stripprefix
         - traefik.http.middlewares.api-stripprefix.stripprefix.prefixes=/api
-        - traefik.http.routers.bechdel-lists-api.entrypoints=https
-        - traefik.http.routers.bechdel-lists-api.tls=true
-        - traefik.http.routers.bechdel-lists-api.tls.certresolver=le
+        - traefik.http.routers.bechdel-lists-api-https.entrypoints=https
+        - traefik.http.routers.bechdel-lists-api-https.tls=true
+        - traefik.http.routers.bechdel-lists-api-https.tls.certresolver=le
         - traefik.http.services.bechdel-lists-api.loadbalancer.server.port=5000
 
   client:

--- a/services/api/config/application.rb
+++ b/services/api/config/application.rb
@@ -40,6 +40,7 @@ module ApiRails
 
     # config.middleware.use Rack::MethodOverride
 
+    config.hosts << 'loadbalancer' unless Rails.env.production?
     config.hosts << ENV['HOST']
   end
 end

--- a/services/api/config/application.rb
+++ b/services/api/config/application.rb
@@ -40,7 +40,9 @@ module ApiRails
 
     # config.middleware.use Rack::MethodOverride
 
-    config.hosts << 'loadbalancer' unless Rails.env.production?
     config.hosts << ENV['HOST']
+
+    # This is for local testing of the monitoring stack, which targets the local traefik host
+    config.hosts << 'traefik' unless Rails.env.production?
   end
 end


### PR DESCRIPTION
* Adds support for traefik host in development mode
* Enables https redirects for api endpoints, which fixes issues (unsure exact cause) with prometheus targets in prod